### PR TITLE
[VTOL-11] read full calibration data

### DIFF
--- a/flight-controller/src/main/scala/io/github/mouslihabdelhakim/vtol/Main.scala
+++ b/flight-controller/src/main/scala/io/github/mouslihabdelhakim/vtol/Main.scala
@@ -43,7 +43,7 @@ object Main extends IOApp {
 
     val barometer = MS5611[IO]
       .flatTap(_.reset())
-      .flatMap(_.promRead())
+      .flatMap(_.calibration())
       .map(println)
 
     List(

--- a/flight-controller/src/main/scala/io/github/mouslihabdelhakim/vtol/Main.scala
+++ b/flight-controller/src/main/scala/io/github/mouslihabdelhakim/vtol/Main.scala
@@ -20,7 +20,7 @@ object Main extends IOApp {
           .evals(
             IO.pure(
               List
-                .fill(100)(
+                .fill(10)(
                   List(
                     RGB.Color.Black,
                     RGB.Color.Red,

--- a/flight-controller/src/main/scala/io/github/mouslihabdelhakim/vtol/Main.scala
+++ b/flight-controller/src/main/scala/io/github/mouslihabdelhakim/vtol/Main.scala
@@ -44,6 +44,7 @@ object Main extends IOApp {
     val barometer = MS5611[IO]
       .flatTap(_.reset())
       .flatMap(_.promRead())
+      .map(println)
 
     List(
       barometer,

--- a/flight-controller/src/main/scala/io/github/mouslihabdelhakim/vtol/services/navio2/barometer/Implementation.scala
+++ b/flight-controller/src/main/scala/io/github/mouslihabdelhakim/vtol/services/navio2/barometer/Implementation.scala
@@ -20,7 +20,7 @@ class Implementation[F[_]](
     _ <- T.sleep(100.milliseconds)
   } yield ()
 
-  override def promRead(): F[CalibrationData] = for {
+  override def calibration(): F[CalibrationData] = for {
     c1 <- readPromRegister(PromReadC1)
     c2 <- readPromRegister(PromReadC2)
     c3 <- readPromRegister(PromReadC3)

--- a/flight-controller/src/main/scala/io/github/mouslihabdelhakim/vtol/services/navio2/barometer/Implementation.scala
+++ b/flight-controller/src/main/scala/io/github/mouslihabdelhakim/vtol/services/navio2/barometer/Implementation.scala
@@ -5,7 +5,7 @@ import cats.syntax.functor._
 import cats.syntax.flatMap._
 import cats.effect.{Sync, Timer}
 import com.pi4j.io.i2c.{I2CBus, I2CDevice, I2CFactory}
-import io.github.mouslihabdelhakim.vtol.services.navio2.barometer.Implementation.{PromReadC1, Reset}
+import io.github.mouslihabdelhakim.vtol.services.navio2.barometer.Implementation._
 import io.github.mouslihabdelhakim.vtol.services.navio2.barometer.MS5611.CalibrationData
 
 class Implementation[F[_]](
@@ -20,14 +20,19 @@ class Implementation[F[_]](
     _ <- T.sleep(100.milliseconds)
   } yield ()
 
-  override def promRead(): F[CalibrationData] =
-    read2Bytes(PromReadC1).map(_ => CalibrationData(0, 0, 0, 0, 0, 0))
+  override def promRead(): F[CalibrationData] = for {
+    c1 <- readPromRegister(PromReadC1)
+    c2 <- readPromRegister(PromReadC2)
+    c3 <- readPromRegister(PromReadC3)
+    c4 <- readPromRegister(PromReadC4)
+    c5 <- readPromRegister(PromReadC5)
+    c6 <- readPromRegister(PromReadC6)
+  } yield CalibrationData(c1, c2, c3, c4, c5, c6)
 
-  private def read2Bytes(register: Int): F[Array[Byte]] = S.delay {
+  private def readPromRegister(register: Int): F[Long] = S.delay {
     val buffer = Array.ofDim[Byte](2)
     i2CDevice.read(register, buffer, 0, 2)
-    println(buffer.mkString)
-    buffer
+    (buffer(0) & 0xffL) * 256L + (buffer(1) & 0xffL)
   }
 
 }
@@ -53,10 +58,10 @@ object Implementation {
 
   private val Reset      = 0x1e.toByte
   private val PromReadC1 = 0xa2
-  /*private val PromReadC2 = 0xa4.toByte
-  private val PromReadC3 = 0xa6.toByte
-  private val PromReadC4 = 0xa8.toByte
-  private val PromReadC5 = 0xaa.toByte
-  private val PromReadC6 = 0xac.toByte
-   */
+  private val PromReadC2 = 0xa4
+  private val PromReadC3 = 0xa6
+  private val PromReadC4 = 0xa8
+  private val PromReadC5 = 0xaa
+  private val PromReadC6 = 0xac
+
 }

--- a/flight-controller/src/main/scala/io/github/mouslihabdelhakim/vtol/services/navio2/barometer/MS5611.scala
+++ b/flight-controller/src/main/scala/io/github/mouslihabdelhakim/vtol/services/navio2/barometer/MS5611.scala
@@ -7,7 +7,7 @@ trait MS5611[F[_]] {
 
   def reset(): F[Unit]
 
-  def promRead(): F[CalibrationData]
+  def calibration(): F[CalibrationData]
 
 }
 


### PR DESCRIPTION
Output from this PR

```
CalibrationData(47446,47691,30403,27867,32701,29271)
```

Output from the navio python implementation
```
('C1', 47446.0)
('C2', 47691.0)
('C3', 30403.0)
('C4', 27867.0)
('C5', 32701.0)
('C6', 29271.0)
```